### PR TITLE
mockito 1.5.4 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,20 +18,19 @@ requirements:
   host:
     - pip
     - python
-    - wheel
-    - setuptools
+    - hatchling
   run:
     - python
 
 test:
+  source_files:
+    - tests
   imports:
     - mockito
   requires:
     - pip
     - pytest
     - numpy
-  source_files:
-    - tests/
   commands:
     - pip check
     - pytest tests
@@ -39,8 +38,10 @@ test:
 
 about:
   home: https://github.com/kaste/mockito-python
-  summary: Mockito is a spying framework.
-  description: Mockito is a spying framework originally based on the Java library with the same name.
+  summary: Mockito is a spying framework originally based on the Java library with the same name.
+  description: |
+    Mockito is a spying framework originally based on the Java library with the same name. 
+    (Actually we invented the strict stubbing mode back in 2009.)
   license: MIT
   license_family: MIT
   license_file: LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "mockito" %}
-{% set version = "1.4.0" %}
-
+{% set version = "1.5.4" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +7,7 @@ package:
 
 source:
   url: https://github.com/kaste/mockito-python/archive/{{ version }}.tar.gz
-  sha256: fe0614d07bf0f762f9b0e7b7183788e80941950315f58dfa2d405415afc9e65a
+  sha256: 20cd741cb1c74fe55b2f16c04802002d840d4cf448f59badf1d4d0c1397dd116
 
 build:
   number: 0
@@ -36,6 +35,7 @@ test:
   commands:
     - pip check
     - pytest tests
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
 
 about:
   home: https://github.com/kaste/mockito-python


### PR DESCRIPTION
mockito 1.5.4 

**Destination channel:** Defaults

### Links

- [PKG-8536]
- dev_url:        https://github.com/kaste/mockito-python/tree/1.5.4
- conda_forge:    https://github.com/conda-forge/mockito-feedstock
- pypi:           https://pypi.org/project/mockito/1.5.4
- pypi inspector: https://inspector.pypi.io/project/mockito/1.5.4

### Explanation of changes:

- new version number


[PKG-8536]: https://anaconda.atlassian.net/browse/PKG-8536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ